### PR TITLE
Added Footer Component

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -1,0 +1,71 @@
+import { Box, Heading, Image, Link, Text } from "theme-ui";
+
+const Footer = ({ noBg }: { noBg?: boolean }) => {
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        background: noBg ? "none" : "url('/backgrounds/lined-paper.png')",
+        backgroundSize: noBg
+          ? "initial"
+          : ["contain", "contain", "cover!important"],
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        flexDirection: "column",
+        gap: "20px",
+        p: [4, 4, 5],
+        pt: 6,
+        position: "relative",
+      }}
+    >
+      <Heading
+        as="h2"
+        sx={{
+          mt: 6,
+          position: "relative",
+          fontFamily: "moonblossom",
+          fontWeight: 300,
+        }}
+      >
+        Scrapyard Hamburg
+        <Image
+          src="/elements/doodles/pink-underline.svg"
+          sx={{
+            position: "absolute",
+            bottom: "0",
+            left: "50%",
+            transform: "translateX(-50%) translateY(75%)",
+          }}
+          alt="Pink Underline"
+        />
+      </Heading>
+      <Text
+        sx={{
+          fontFamily: "moonblossom",
+          mb: -2,
+          textAlign: "center",
+        }}
+      >
+        Made with ♡ by teenagers, for teenagers at Hack Club
+      </Text>
+      <Text
+        sx={{
+          fontFamily: "moonblossom",
+          mt: 0,
+          textAlign: "center",
+        }}
+      >
+        <Link href="https://hackclub.com">Hack Club</Link>{" "}
+        <span style={{ transform: "scale(2)" }}>・</span>{" "}
+        <Link href="https://hackclub.com/slack">Slack</Link>{" "}
+        <span style={{ transform: "scale(2)" }}>・</span>{" "}
+        <Link href="https://hackclub.com/clubs">Ags</Link>{" "}
+        <span style={{ transform: "scale(2)" }}>・</span>{" "}
+        <Link href="https://hackclub.com/hackathons">Hackathons</Link>
+      </Text>
+    </Box>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
### TL;DR
Added a new Footer component with Hack Club branding and links.

### What changed?
Created a new Footer component that includes:
- Scrapyard Hamburg heading with decorative underline
- "Made with ♡" message
- Navigation links to Hack Club resources
- Optional background toggle through `noBg` prop
- Styled using theme-ui components

### How to test?
1. Import and add the Footer component to a page
2. Verify the footer renders with proper styling and spacing
3. Check that all links are functional and direct to correct Hack Club pages
4. Test with `noBg={true}` to ensure background can be toggled off

### Why make this change?
To provide consistent branding and navigation across the site while maintaining the Hack Club identity and providing easy access to important Hack Club resources.