### PR TITLE
Updated HCB Donation Links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -791,7 +791,7 @@ export default function Home() {
               <>
                 Im allgemeinen könnt ihr uns immer unter{" "}
                 <Link
-                  href="https://hcb.hackclub.com/donations/start/scrapyard-hamburg"
+                  href="https://hcb.hackclub.com/donations/start/hamburg"
                   target="_blank"
                   sx={{
                     textDecoration: "underline",
@@ -822,7 +822,7 @@ export default function Home() {
                 einfach gucken wollt was ein Hackathon für ausgaben generiert
                 geht einfach auf{" "}
                 <Link
-                  href="https://hcb.hackclub.com/scrapyard-hamburg/transactions"
+                  href="https://hcb.hackclub.com/hamburg/transactions"
                   target="_blank"
                   sx={{
                     textDecoration: "underline",


### PR DESCRIPTION
### TL;DR
Updated HackClub Bank donation and transaction links to use the correct organization slug.

### What changed?
- Modified the donation link from `scrapyard-hamburg` to `hamburg`
- Updated the transaction history link from `scrapyard-hamburg` to `hamburg`

### How to test?
1. Click on the donation link to verify it redirects to the correct HackClub Bank page
2. Click on the transaction history link to ensure it shows the proper organization's transactions

### Why make this change?
The organization slug in the HackClub Bank URLs was incorrect, preventing users from accessing the proper donation and transaction pages. This fix ensures visitors can properly view and interact with our financial information.